### PR TITLE
Multi Instance on single App Service Plan

### DIFF
--- a/azuredeploy-prod.json
+++ b/azuredeploy-prod.json
@@ -36,6 +36,13 @@
                 "description": "Specifies the name of the key vault."
             }
         },
+        "existingAppServicePlanID": {
+            "type": "string",
+            "defaultValue": "none",
+            "metadata": {
+                "description": "Provide the AppServicePlan ID of an existing App Service Plan. Keep default value 'none' if you want to create a new one."
+            }
+        },
         "appServicePlanName": {
             "type": "string",
             "maxLength": 40
@@ -74,6 +81,9 @@
                     },
                     "keyVaultName": {
                         "value": "[parameters('keyVaultName')]"
+                    },
+                    "existingAppServicePlanID": {
+                        "value": "[parameters('existingAppServicePlanID')]"
                     },
                     "appServicePlanName": {
                         "value": "[parameters('appServicePlanName')]"

--- a/azuredeploy-prod.json
+++ b/azuredeploy-prod.json
@@ -63,7 +63,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/scepman/install/master/nestedtemplates/scepman.json",
+                    "uri": "https://raw.githubusercontent.com/grabery/install/master/nestedtemplates/scepman.json",
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {

--- a/nestedtemplates/appConfig.json
+++ b/nestedtemplates/appConfig.json
@@ -2,6 +2,12 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
+        "existingAppServicePlanID": {
+            "type": "string",
+            "metadata": {
+                "description": "Provide the AppServicePlan ID of an existing App Service Plan. Keep default value 'none' if you want to create a new one."
+            }
+        },
         "AppServicePlanName": {
             "type": "string",
             "metadata": {
@@ -69,7 +75,7 @@
             "name": "[parameters('appServiceName')]",
             "location": "[parameters('location')]",
             "properties": {
-                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('AppServicePlanName'))]",
+                "serverFarmId": "[if(equals(parameters('existingAppServicePlanID'), 'none'), resourceId('Microsoft.Web/serverfarms', parameters('AppServicePlanName')), parameters('existingAppServicePlanID'))]",
                 "httpsOnly": false,
                 "clientAffinityEnabled": false,
                 "siteConfig": {

--- a/nestedtemplates/appSvc.json
+++ b/nestedtemplates/appSvc.json
@@ -24,7 +24,7 @@
 
     "resources": [
         {
-            "condition": "[not(equals(parameters('existingAppServicePlanID'), 'none'))]",
+            "condition": "[equals(parameters('existingAppServicePlanID'), 'none')]",
             "apiVersion": "2019-08-01",
             "type": "Microsoft.Web/serverfarms",
             "name": "[parameters('AppServicePlanName')]",

--- a/nestedtemplates/appSvc.json
+++ b/nestedtemplates/appSvc.json
@@ -24,6 +24,7 @@
 
     "resources": [
         {
+            "condition": "[not(equals(parameters('existingAppServicePlanID'), 'none'))]",
             "apiVersion": "2019-08-01",
             "type": "Microsoft.Web/serverfarms",
             "name": "[parameters('AppServicePlanName')]",

--- a/nestedtemplates/appSvc.json
+++ b/nestedtemplates/appSvc.json
@@ -2,6 +2,12 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
+        "existingAppServicePlanID": {
+            "type": "string",
+            "metadata": {
+                "description": "Provide the AppServicePlan ID of an existing App Service Plan. Keep default value 'none' if you want to create a new one."
+            }
+        },
         "AppServicePlanName": {
             "type": "string",
             "metadata": {
@@ -43,7 +49,7 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('AppServicePlanName'))]"
+                "serverFarmId": "[if(equals(parameters('existingAppServicePlanID'), 'none'), resourceId('Microsoft.Web/serverfarms', parameters('AppServicePlanName')), parameters('existingAppServicePlanID'))]"
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/serverfarms', parameters('AppServicePlanName'))]"

--- a/nestedtemplates/scepman.json
+++ b/nestedtemplates/scepman.json
@@ -124,6 +124,9 @@
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
+                    "existingAppServicePlanID": {
+                        "value": "[parameters('existingAppServicePlanID')]"
+                    },
                     "AppServicePlanName": {
                         "value": "[parameters('AppServicePlanName')]"
                     },

--- a/nestedtemplates/scepman.json
+++ b/nestedtemplates/scepman.json
@@ -35,6 +35,12 @@
                 "description": "Specifies the name of the key vault."
             }
         },
+        "existingAppServicePlanID": {
+            "type": "string",
+            "metadata": {
+                "description": "Provide the AppServicePlan ID of an existing App Service Plan. Keep default value 'none' if you want to create a new one."
+            }
+        },
         "appServicePlanName": {
             "type": "string",
             "maxLength": 40
@@ -65,6 +71,9 @@
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
+                    "existingAppServicePlanID": {
+                        "value": "[parameters('existingAppServicePlanID')]"
+                    },
                     "AppServicePlanName": {
                         "value": "[parameters('AppServicePlanName')]"
                     },

--- a/nestedtemplates/scepman.json
+++ b/nestedtemplates/scepman.json
@@ -67,7 +67,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/scepman/install/master/nestedtemplates/appSvc.json",
+                    "uri": "https://raw.githubusercontent.com/grabery/install/master/nestedtemplates/appSvc.json",
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
@@ -93,7 +93,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/scepman/install/master/nestedtemplates/vault.json",
+                    "uri": "https://raw.githubusercontent.com/grabery/install/master/nestedtemplates/vault.json",
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
@@ -120,7 +120,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/scepman/install/master/nestedtemplates/appConfig.json",
+                    "uri": "https://raw.githubusercontent.com/grabery/install/master/nestedtemplates/appConfig.json",
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {


### PR DESCRIPTION
Hello

I added the possibility of having a single App Service Plan but running multiple SCEPman instances on that one. This way, you do not need to always create a new App Service Plan and can just use the existing one. 

I did discuss this already with you by mail & phone. This is my version, which I successfully tested and does cover my needs. Hope you like it.

Be aware, that you have to readjust the nested template links (replace only "grabery" in the link)