### PR TITLE
Disable public access if private endpoints are deployed

### DIFF
--- a/nestedtemplates/stgAccount.bicep
+++ b/nestedtemplates/stgAccount.bicep
@@ -114,6 +114,7 @@ resource StorageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
     isNfsV3Enabled: false
     minimumTlsVersion: 'TLS1_2'
     supportsHttpsTrafficOnly: true
+    publicNetworkAccess: ((privateEndpointName == 'None') ? 'Enabled' : 'Disabled')
     networkAcls: {
       bypass: 'None'
       defaultAction: ((privateEndpointName == 'None') ? 'Allow' : 'Deny')

--- a/nestedtemplates/vault.bicep
+++ b/nestedtemplates/vault.bicep
@@ -40,6 +40,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
       name: 'premium'
       family: 'A'
     }
+    publicNetworkAccess: ((privateEndpointName == 'None') ? 'Enabled' : 'Disabled')
     networkAcls: {
       bypass: 'None'
       defaultAction: ((privateEndpointName == 'None') ? 'Allow' : 'Deny')


### PR DESCRIPTION
Add bicep parameter to disable the public access to Key Vault and Storage Account if the deployment includes private endpoints.